### PR TITLE
Using uuid lib to avoid conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   },
   "dependencies": {
     "deline": "^1.0.2",
-    "invariant": "^2.2.2"
+    "invariant": "^2.2.2",
+    "uuid": "^3.0.1"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,11 +1,5 @@
+import uuid from 'uuid';
 import { KEY, LIFECYCLE } from './constants';
-
-let i = 0;
-
-const uuid = () => {
-  i += 1;
-  return `.p${i}`;
-};
 
 function isPromise(obj) {
   return !!obj && typeof obj.then === 'function';
@@ -28,7 +22,7 @@ function handlePromise(dispatch, getState, action) {
 
   // it is sometimes useful to be able to track the actions and associated promise lifecycle with a
   // sort of unique identifier. This is that.
-  const transactionId = uuid();
+  const transactionId = uuid.v4();
   const startPayload = payload;
 
   dispatch({


### PR DESCRIPTION
The UUID used before was a function that just increments a variable. Just to avoid conflicts as a precaution I made this PR that uses a small lib to generate a UUID value using RFC documentation.