### PR TITLE
Improve README.md state change examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,18 @@ export function fooReducer(state = initialState, action) {
 ```
 
 
-**Note:** The example uses `{ ...state }` syntax that is called [Object rest spread properties](https://github.com/sebmarkbage/ecmascript-rest-spread).
+**Note:** The example uses `{ ...state }` syntax that is called [Object rest spread properties](https://github.com/sebmarkbage/ecmascript-rest-spread). If you'd prefer the API of [Immutable.js](https://facebook.github.io/immutable-js/), you could write code like the following:
+
+```js
+switch (type) {
+  case LOAD_FOO_STARTED:
+    return state
+      .set('isLoading', true)
+      .set('fooError', null);
+  case LOAD_FOO_SUCCESS:
+    // ...
+}
+```
 
 ### Data fetching with redux-pack (new way)
 

--- a/README.md
+++ b/README.md
@@ -109,16 +109,17 @@ import { handle } from 'redux-pack';
 export function fooReducer(state = initialState, action) {
   const { type, payload } = action;
   switch (type) {
-    case LOAD_FOO: return handle(state, action, {
-      start: s => ({
-        ...s,
-        isLoading: true,
-        fooError: null
-      }),
-      finish: s => ({ ...s, isLoading: false }),
-      failure: s => ({ ...s, fooError: payload }),
-      success: s => ({ ...s, foo: payload }),
-    });
+    case LOAD_FOO:
+      return handle(state, action, {
+        start: s => ({
+          ...s,
+          isLoading: true,
+          fooError: null
+        }),
+        finish: s => ({ ...s, isLoading: false }),
+        failure: s => ({ ...s, fooError: payload }),
+        success: s => ({ ...s, foo: payload }),
+      });
     default:
       return state;
   }
@@ -223,13 +224,14 @@ const initialState = {
 export function fooReducer(state = initialState, action) {
   const { type, payload } = action;
   switch (type) {
-    case LOAD_FOO: return handle(state, action, {
-      start: s => ({ ...s, isLoading: true, error: null, foo: null })
-      finish: s => ({ ...s, isLoading: false }),
-      failure: s => ({ ...s, error: payload })),
-      success: s => ({ ...s, foo: payload }),
-      always: s => s, // unnecessary, for the sake of example
-    });
+    case LOAD_FOO:
+      return handle(state, action, {
+        start: s => ({ ...s, isLoading: true, error: null, foo: null })
+        finish: s => ({ ...s, isLoading: false }),
+        failure: s => ({ ...s, error: payload })),
+        success: s => ({ ...s, foo: payload }),
+        always: s => s, // unnecessary, for the sake of example
+      });
     default:
       return state;
   }

--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ export function loadFoo() {
 }
 ```
 
+**Note:** The example uses `{ ...state }` syntax that is called [Object rest spread properties](https://github.com/sebmarkbage/ecmascript-rest-spread).
+
 ### Adding side-effects with event hooks
 
 You might want to add side effects (like sending analytics events or navigate to different views) based on promise results.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ export function fooReducer(state = initialState, action) {
 ```
 
 
+**Note:** The example uses `{ ...state }` syntax that is called [Object rest spread properties](https://github.com/sebmarkbage/ecmascript-rest-spread).
+
 ### Data fetching with redux-pack (new way)
 
 With redux-pack, we only need to define a single action constant for the entire promise lifecycle, and then return the promise directly with a `promise` namespace specified:

--- a/README.md
+++ b/README.md
@@ -38,23 +38,30 @@ export function loadFoo(id) {
 ```
 
 In the reducer, you would handle each action individually in your reducer:
+
 ```js
 // reducer.js
 export function fooReducer(state = initialState, action) {
   const { type, payload } = action;
   switch (type) {
     case LOAD_FOO_STARTED:
-      return state
-        .set('isLoading', true)
-        .set('fooError', null);
+      return {
+        ...state,
+        isLoading: true,
+        fooError: null
+      };
     case LOAD_FOO_SUCCESS:
-      return state
-        .set('isLoading', false)
-        .set('foo', payload);
+      return {
+        ...state,
+        isLoading: false,
+        foo: payload
+      };
     case LOAD_FOO_FAILED:
-      return state
-        .set('isLoading', false)
-        .set('fooError', payload);
+      return {
+        ...state,
+        isLoading: false,
+        fooError: payload
+      };
     default:
       return state;
   }
@@ -81,6 +88,7 @@ export function loadFoo(id) {
 ```
 
 In the reducer, you handle the action with redux-pack's `handle` function, where you can specify several smaller "reducer" functions for each lifecycle. `finish` is called for both resolving/rejecting, `start` is called at the beginning, `success` is called on resolve, `failure` is called on reject, and `always` is called for all of them.
+
 ```js
 // reducer.js
 import { handle } from 'redux-pack';
@@ -89,12 +97,14 @@ export function fooReducer(state = initialState, action) {
   const { type, payload } = action;
   switch (type) {
     case LOAD_FOO: return handle(state, action, {
-      start: s => s
-        .set('isLoading', true)
-        .set('fooError', null),
-      finish: s => s.set('isLoading', false),
-      failure: s => s.set('fooError', payload),
-      success: s => s.set('foo', payload),
+      start: s => ({
+        ...s,
+        isLoading: true,
+        fooError: null
+      }),
+      finish: s => ({ ...s, isLoading: false }),
+      failure: s => ({ ...s, fooError: payload }),
+      success: s => ({ ...s, foo: payload }),
     });
     default:
       return state;


### PR DESCRIPTION
As discussed in [this thread on Twitter](https://twitter.com/intelligibabble/status/809455565160099840), it might be better to showcase both Immutable.js API and one more closer to JS, whilst still advertising for the API of Immutable.js so readers of the documentation wouldn't get confused about the surprising use of `s.set()` API

I also used [Object Rest/Spread Properties for ECMAScript](https://github.com/sebmarkbage/ecmascript-rest-spread) syntax for the first reducer examples as that is the same on as used in the "How to" section later in the README

Ref #16, closes #17