### PR TITLE
Return values when chaining promises

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -49,7 +49,7 @@ function handlePromise(dispatch, getState, action) {
     });
     handleEventHook(meta, 'onSuccess', data, getState);
     handleEventHook(meta, 'onFinish', true, getState);
-    return { success: true, payload: data };
+    return { payload: data };
   };
 
   const failure = error => {
@@ -66,7 +66,7 @@ function handlePromise(dispatch, getState, action) {
     });
     handleEventHook(meta, 'onFailure', error, getState);
     handleEventHook(meta, 'onFinish', false, getState);
-    return { success: false, payload: error };
+    return { error: true, payload: error };
   };
 
   // return the promise. In this case, when users dispatch an action with a promise

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -49,6 +49,7 @@ function handlePromise(dispatch, getState, action) {
     });
     handleEventHook(meta, 'onSuccess', data, getState);
     handleEventHook(meta, 'onFinish', true, getState);
+    return { success: true, payload: data };
   };
 
   const failure = error => {
@@ -65,6 +66,7 @@ function handlePromise(dispatch, getState, action) {
     });
     handleEventHook(meta, 'onFailure', error, getState);
     handleEventHook(meta, 'onFinish', false, getState);
+    return { success: false, payload: error };
   };
 
   // return the promise. In this case, when users dispatch an action with a promise


### PR DESCRIPTION
Issue #3 describes an callback signature for chaining promises

Issue #41 demonstrates that it was never implemented. This PR adds the relevant return values as I greatly prefer chaining to the 'event-hook' system.


(Sidenote: no tests?)